### PR TITLE
Migrate to panel-material-ui

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ dependencies = [
     "lumen >=0.6.1,<2.0.0",
     "packaging >=26.0.0",
     "panel >=1.9.1,<2.0.0",
+    "panel-material-ui >=0.12.0,<2.0.0",
     "platformdirs >=4.6.0,<5.0.0",
     "pydantic >=2.12.1,<4.0.0",
     "pydantic-settings >=2.13.0,<4.0.0",

--- a/src/gandharva/_app/_base.py
+++ b/src/gandharva/_app/_base.py
@@ -12,7 +12,7 @@
 # implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-__all__ = ["App", "normalize"]
+__all__ = ["App", "normalize", "summary"]
 
 import abc
 import inspect
@@ -50,9 +50,7 @@ class App(abc.ABC):
 
     @classmethod
     def app_summary(cls) -> str:
-        if lines := cls.app_description().splitlines():
-            return lines[0].rstrip(".")
-        return ""
+        return summary(cls.app_description())
 
     @final
     def __init__(self, run_mode: Literal["api", "cli", "gui"]) -> None:
@@ -64,6 +62,12 @@ def normalize(name: str) -> str:
         pydantic.alias_generators.to_snake(name).removeprefix("_"),
         validate=True,
     )
+
+
+def summary(description: str) -> str:
+    # str.split(str) never returns a empty list, see
+    # https://docs.python.org/3/library/stdtypes.html#str.split
+    return description.split("\n", maxsplit=1)[0].rstrip(".").strip()
 
 
 os.environ.setdefault(

--- a/src/gandharva/_app/_panel.py
+++ b/src/gandharva/_app/_panel.py
@@ -17,6 +17,7 @@ __all__ = ["App"]
 import asyncio
 import contextlib
 import functools
+import inspect
 import math
 from collections.abc import Callable, Iterable, Mapping
 from typing import TYPE_CHECKING, cast
@@ -275,6 +276,8 @@ class _Sidebar(lumen.schema.JSONSchema):
         schema: Mapping[str, int],
     ) -> tuple[type, dict[str, Any]]:
         kwargs: dict[str, int | str] = {"step": 1}
+        if placeholder := _summary(schema):
+            kwargs["placeholder"] = placeholder
         start = max(
             schema.get("exclusiveMinimum", _NINF) + 1,
             schema.get("minimum", _NINF),
@@ -285,7 +288,7 @@ class _Sidebar(lumen.schema.JSONSchema):
         )
         match start > _NINF, end < math.inf:
             case True, True:
-                if start < end:
+                if start < end and "placeholder" not in kwargs:
                     kwargs["fixed_start"] = int(start)
                     kwargs["fixed_end"] = int(end)
                     return pn.widgets.EditableIntSlider, kwargs
@@ -308,6 +311,8 @@ class _Sidebar(lumen.schema.JSONSchema):
         schema: Mapping[str, float],
     ) -> tuple[type, dict[str, Any]]:
         kwargs: dict[str, float | str] = {"step": .1}
+        if placeholder := _summary(schema):
+            kwargs["placeholder"] = placeholder
         start = schema.get("exclusiveMinimum", _NINF)
         if start > _NINF:
             start = math.nextafter(start, math.inf)
@@ -318,7 +323,7 @@ class _Sidebar(lumen.schema.JSONSchema):
         end = min(end, schema.get("maximum", math.inf))
         match start > _NINF, end < math.inf:
             case True, True:
-                if start < end:
+                if start < end and "placeholder" not in kwargs:
                     kwargs["fixed_start"] = start
                     kwargs["fixed_end"] = end
                     return pn.widgets.EditableFloatSlider, kwargs
@@ -354,13 +359,13 @@ class _Sidebar(lumen.schema.JSONSchema):
                 return pmui.DatePicker, {}
             case {"format": "time"}:
                 return pmui.TimePicker, {"clock": "24h"}
-            case {"maxLength": max_length}:
-                return pmui.TextInput, {
-                    "max_length": max_length,
-                    "size": "small",
-                }
             case _:
-                return pmui.TextInput, {"size": "small"}
+                kwargs: dict[str, object] = {"size": "small"}
+                if max_length := schema.get("maxLength"):
+                    kwargs["max_length"] = max_length
+                if placeholder := _summary(schema):
+                    kwargs["placeholder"] = placeholder
+                return pmui.TextInput, kwargs
 
     @override
     def _widget_type(
@@ -370,3 +375,9 @@ class _Sidebar(lumen.schema.JSONSchema):
     ) -> tuple[type, dict[str, object]]:
         wtype, kwargs = super()._widget_type(prop, schema)  # pyright: ignore[reportUnknownMemberType, reportUnknownVariableType]
         return wtype, dict(kwargs, sizing_mode="stretch_width")  # pyright: ignore[reportUnknownArgumentType]
+
+
+def _summary(schema: Mapping[str, Any]) -> str:
+    if description := schema.get("description"):
+        return _base.summary(inspect.cleandoc(description))
+    return ""

--- a/src/gandharva/_app/_panel.py
+++ b/src/gandharva/_app/_panel.py
@@ -259,21 +259,22 @@ class _Sidebar(lumen.schema.JSONSchema):
         self,
         schema: Mapping[str, object],
     ) -> tuple[type, dict[str, object]]:
-        return pmui.Checkbox, {}
+        # https://github.com/panel-extensions/panel-material-ui/issues/392
+        return pmui.Checkbox, {"size": "small"}
 
     @override
     def _enum(
         self,
         schema: Mapping[str, object],
     ) -> tuple[type, dict[str, object]]:
-        return pmui.Select, {"options": schema["enum"]}
+        return pmui.Select, {"options": schema["enum"], "size": "small"}
 
     @override
     def _integer_type(
         self,
         schema: Mapping[str, int],
-    ) -> tuple[type, dict[str, int]]:
-        kwargs = {"step": 1}
+    ) -> tuple[type, dict[str, Any]]:
+        kwargs: dict[str, int | str] = {"step": 1}
         start = max(
             schema.get("exclusiveMinimum", _NINF) + 1,
             schema.get("minimum", _NINF),
@@ -298,14 +299,15 @@ class _Sidebar(lumen.schema.JSONSchema):
                 kwargs["end"] = int(end)
             case False, False:
                 pass
+        kwargs["size"] = "small"
         return pmui.IntInput, kwargs
 
     @override
     def _number_type(
         self,
         schema: Mapping[str, float],
-    ) -> tuple[type, dict[str, float]]:
-        kwargs = {"step": .1}
+    ) -> tuple[type, dict[str, Any]]:
+        kwargs: dict[str, float | str] = {"step": .1}
         start = schema.get("exclusiveMinimum", _NINF)
         if start > _NINF:
             start = math.nextafter(start, math.inf)
@@ -330,6 +332,7 @@ class _Sidebar(lumen.schema.JSONSchema):
                 kwargs["end"] = end
             case False, False:
                 pass
+        kwargs["size"] = "small"
         return pmui.FloatInput, kwargs
 
     def _object_type(
@@ -352,9 +355,12 @@ class _Sidebar(lumen.schema.JSONSchema):
             case {"format": "time"}:
                 return pmui.TimePicker, {"clock": "24h"}
             case {"maxLength": max_length}:
-                return pmui.TextInput, {"max_length": max_length}
+                return pmui.TextInput, {
+                    "max_length": max_length,
+                    "size": "small",
+                }
             case _:
-                return pmui.TextInput, {}
+                return pmui.TextInput, {"size": "small"}
 
     @override
     def _widget_type(

--- a/src/gandharva/_app/_panel.py
+++ b/src/gandharva/_app/_panel.py
@@ -23,6 +23,7 @@ from typing import TYPE_CHECKING, cast
 
 import lumen.schema  # pyright: ignore[reportMissingTypeStubs]
 import panel as pn
+import panel_material_ui as pmui
 import param
 import pydantic
 from hypothesis_jsonschema import _resolve  # noqa: PLC2701
@@ -72,7 +73,7 @@ class App(_pydantic.App):
     @classmethod
     def panel_template_params(cls) -> gd.typing.BasicTemplateParameters:
         title = _base.normalize(cls.__name__).replace("-", " ")
-        return {"title": title[:1].upper() + title[1:]}
+        return {"sidebar_width": 500, "title": title[:1].upper() + title[1:]}
 
     @classmethod
     def __panel__(cls) -> "TViewable":  # noqa: PLW3201
@@ -96,7 +97,7 @@ class App(_pydantic.App):
             _resolve.resolve_all_refs(model.model_json_schema())["properties"],  # pyright: ignore[reportArgumentType, reportUnknownMemberType]
         )
         kwargs = dict(cls.panel_button_params(), on_click=None)
-        submit = pn.widgets.Button(**kwargs)
+        submit = pmui.Button(**kwargs)
         sidebar.append(
             pn.Row(
                 pn.Spacer(sizing_mode="stretch_width"),
@@ -174,7 +175,7 @@ class App(_pydantic.App):
     def _panel_update(
         cls,
         callback: Callable[[], "Viewable"],
-        submit: pn.widgets.Button,
+        submit: pmui.Button,
         indicator: pn.widgets.indicators.BooleanIndicator | None = None,
     ) -> tuple["Viewable", contextlib.ExitStack]:
         with contextlib.ExitStack() as stack:
@@ -249,9 +250,23 @@ class _Sidebar(lumen.schema.JSONSchema):
     ) -> tuple["type[WidgetBase]", dict[str, object]]:
         match schema:
             case {"items": {"enum": [*options]}}:
-                return pn.widgets.MultiSelect, {"options": options}
+                return pmui.MultiSelect, {"options": options}
             case _:
                 return pn.widgets.JSONEditor, {"menu": False, "schema": schema}
+
+    @override
+    def _boolean_type(
+        self,
+        schema: Mapping[str, object],
+    ) -> tuple[type, dict[str, object]]:
+        return pmui.Checkbox, {}
+
+    @override
+    def _enum(
+        self,
+        schema: Mapping[str, object],
+    ) -> tuple[type, dict[str, object]]:
+        return pmui.Select, {"options": schema["enum"]}
 
     @override
     def _integer_type(
@@ -283,7 +298,7 @@ class _Sidebar(lumen.schema.JSONSchema):
                 kwargs["end"] = int(end)
             case False, False:
                 pass
-        return pn.widgets.IntInput, kwargs
+        return pmui.IntInput, kwargs
 
     @override
     def _number_type(
@@ -315,7 +330,7 @@ class _Sidebar(lumen.schema.JSONSchema):
                 kwargs["end"] = end
             case False, False:
                 pass
-        return pn.widgets.FloatInput, kwargs
+        return pmui.FloatInput, kwargs
 
     def _object_type(
         self,
@@ -331,15 +346,15 @@ class _Sidebar(lumen.schema.JSONSchema):
     ) -> tuple[type, dict[str, object]]:
         match schema:
             case {"format": "date-time"}:
-                return pn.widgets.DatetimePicker, {"allow_input": True}
+                return pmui.DatetimePicker, {}
             case {"format": "date"}:
-                return pn.widgets.DatePicker, {}
+                return pmui.DatePicker, {}
             case {"format": "time"}:
-                return pn.widgets.TimePicker, {"clock": "24h"}
+                return pmui.TimePicker, {"clock": "24h"}
             case {"maxLength": max_length}:
-                return pn.widgets.TextInput, {"max_length": max_length}
+                return pmui.TextInput, {"max_length": max_length}
             case _:
-                return pn.widgets.TextInput, {}
+                return pmui.TextInput, {}
 
     @override
     def _widget_type(

--- a/src/gandharva/typing/_panel.py
+++ b/src/gandharva/typing/_panel.py
@@ -127,17 +127,27 @@ class BasicTemplateParameters(TypedDict, extra_items=Any, total=False):
 
 
 class ButtonParameters(_Viewable, total=False):
+    attached: Never
     button_style: Never
     button_type: Never
     clicks: Never
     color: Literal["default", "primary", "success", "info", "light", "danger"]
+    dark_theme: Never
     description: "str | Tooltip | pn.widgets.TooltipIcon | None"
     description_delay: int
     disabled: Never
+    disable_elevation: bool
+    end_icon: str | None
+    href: Never
     icon: str | None
     icon_size: str
+    size: Literal["small", "medium", "large"]
+    sx: dict[str, str]
+    target: Never
+    theme_config: Never
+    use_shadow_dom: Never
     value: Never
-    variant: Literal["solid", "outline"]
+    variant: Literal["contained", "outlined", "text"]
 
 
 class DataFrameParameters(_HTMLBasePane, total=False):

--- a/tests/test_input_types.py
+++ b/tests/test_input_types.py
@@ -18,6 +18,7 @@ from typing import Annotated
 
 import fastapi.testclient
 import panel as pn
+import panel_material_ui as pmui
 import pydantic
 import pydantic_settings
 from typing_extensions import override
@@ -89,7 +90,7 @@ class _App(gd.Gandharva):
 def _assert_submit_button(row: pn.viewable.Viewable) -> None:
     assert isinstance(row, pn.Row)
     space1, button, space2 = row
-    assert isinstance(button, pn.widgets.Button)
+    assert isinstance(button, pmui.Button)
     assert isinstance(space1, pn.Spacer)
     assert isinstance(space2, pn.Spacer)
 


### PR DESCRIPTION
Close #13

We have to increase the sidebar width to fit in with `pmui.DatetimePicker`.

Parameters `fixed_start` and `fixed_end` of `pmui.EditableFloatSlider` and `pmui.EditableIntSlider` are broken in panel-material-ui<=0.12.0. Those widgets won't be touched at this moment.